### PR TITLE
Fix typo in quickstart docs

### DIFF
--- a/docs/quickstart/index.rst
+++ b/docs/quickstart/index.rst
@@ -11,7 +11,7 @@ environment.
 
 Clone the repo::
 
-    $ git clone git@github.com:Netflix-Skunkworks/diffy.git && cd giffy
+    $ git clone git@github.com:Netflix-Skunkworks/diffy.git && cd diffy
 
 Install a virtualenv there::
 


### PR DESCRIPTION
It's only a one letter change, so I've not raised an issue.