### PR TITLE
Don't rely on the absolute path to osquery.

### DIFF
--- a/diffy/config.py
+++ b/diffy/config.py
@@ -205,8 +205,8 @@ DEFAULTS: Dict[str, Union[Iterable[Any], Path, str, bool, None]] = {
     'DIFFY_PAYLOAD_OSQUERY_KEY': '',
     'DIFFY_PAYLOAD_OSQUERY_REGION': 'us-west-2',
     'DIFFY_PAYLOAD_OSQUERY_COMMANDS': [
-        './usr/bin/osqueryi --json "SELECT * FROM crontab"',
-        "./usr/bin/osqueryi --json \"SELECT address, port, name, pid, cmdline FROM listening_ports, processes USING (pid) WHERE protocol = 6 and family = 2 AND address NOT LIKE '127.0.0.%'\"",
+        'osqueryi --json "SELECT * FROM crontab"',
+        "osqueryi --json \"SELECT address, port, name, pid, cmdline FROM listening_ports, processes USING (pid) WHERE protocol = 6 and family = 2 AND address NOT LIKE '127.0.0.%'\"",
     ],
     "DIFFY_PERSISTENCE_PLUGIN": "local-file",
     "DIFFY_TARGET_PLUGIN": "auto-scaling-target",


### PR DESCRIPTION
Using shutil in standard library, we check for osqueryi on the instance first. If it's not present, we can download it from S3, create a link to the local binary, modify ${PATH}, and continue to run it without using
the absolute path.