### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: bionic
 
 matrix:
   include:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -43,7 +43,6 @@ flask-restful==0.3.7
 flask-rq2==18.3
 flask==1.0.2
 future==0.17.1            # via python-jose
-fuzzywuzzy==0.17.0
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11         # via bandit
 gunicorn==19.9.0
@@ -88,9 +87,9 @@ pytest-flask==0.14.0
 pytest==4.4.1
 python-dateutil==2.8.0
 python-jose==2.0.2
-python-levenshtein==0.12.0
 pytz==2019.1
 pyyaml==5.1
+rapidfuzz==0.2.1
 raven[flask]==6.10.0
 redis==3.2.1
 requests==2.21.0          # via aws-xray-sdk, codecov, docker, responses, sphinx

--- a/diffy/accounts.py
+++ b/diffy/accounts.py
@@ -5,7 +5,7 @@
     :license: Apache, see LICENSE for more details.
 """
 import logging
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 from honeybee.extensions import swag
 from honeybee.exceptions import ResolveException

--- a/requirements.in
+++ b/requirements.in
@@ -1,12 +1,11 @@
 boto3
 click
 click-log
-fuzzywuzzy
+rapidfuzz
 jsondiff
 jsonschema
 marshmallow-jsonschema
 python-dateutil
-python-Levenshtein
 PyYAML
 retrying
 swag-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ decorator==4.4.0          # via dogpile.cache
 deepdiff==4.0.6           # via swag-client
 docutils==0.14            # via botocore
 dogpile.cache==0.7.1      # via swag-client
-fuzzywuzzy==0.17.0
 jmespath==0.9.4           # via boto3, botocore, swag-client
 jsondiff==1.1.2
 jsonpickle==1.1           # via deepdiff
@@ -23,8 +22,8 @@ marshmallow==2.19.2       # via marshmallow-jsonschema, swag-client
 ordered-set==3.1          # via deepdiff
 pyrsistent==0.14.11       # via jsonschema
 python-dateutil==2.8.0
-python-levenshtein==0.12.0
 pyyaml==5.1
+rapidfuzz==0.2.1
 retrying==1.3.3
 s3transfer==0.2.0         # via boto3
 simplejson==3.16.0        # via swag-client

--- a/web-requirements.txt
+++ b/web-requirements.txt
@@ -19,7 +19,6 @@ dogpile.cache==0.7.1
 flask-restful==0.3.7
 flask-rq2==18.3
 flask==1.0.2
-fuzzywuzzy==0.17.0
 gunicorn==19.9.0
 inflection==0.3.1
 itsdangerous==1.1.0       # via flask
@@ -34,9 +33,9 @@ marshmallow==2.19.2
 ordered-set==3.1
 pyrsistent==0.14.11
 python-dateutil==2.8.0
-python-levenshtein==0.12.0
 pytz==2019.1              # via flask-restful
 pyyaml==5.1
+rapidfuzz==0.2.1
 raven[flask]==6.10.0
 redis==3.2.1              # via flask-rq2, rq
 retrying==1.3.3


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy. 